### PR TITLE
fixing api bug

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -61,7 +61,7 @@ def format_admin_logs(data):
             i['description'] = json.loads(i['description'])
             if('device' in i['description']):
                 i['description']['device'] = "*****"
-            elif ('phones' in i['description'] ):
+            elif i['description'].get['phones']:
                 for ph in (i['description']['phones']):
                     i['description']['phones'][ph]['number'] = "*****"
             elif ('phone' in i['description'] ):


### PR DESCRIPTION
fixing API bug based on this error:

``` dumping logs
dumped successfully.
Retrieved admin Logs.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/sumologic-duo-security/lambda_function.py", line 102, in lambda_handler
    logs_admin = format_admin_logs(logs_admin)
  File "/opt/sumologic-duo-security/lambda_function.py", line 65, in format_admin_logs
    for ph in (i['description']['phones']):
TypeError: 'NoneType' object is not iterable  ```